### PR TITLE
Allow xargs and find --exec to use allowed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,3 @@ A sample configuration file is provided at `mcp-config.sample.json`.
 ### Environment Variables
 
 - `MCP_CONFIG_PATH`: Path to the configuration file (default: `./mcp-config.json`)
-- `MCP_ALLOWED_DIRECTORIES`: Colon-separated list of directories where commands can be executed (deprecated, use `allowedDirectories` in config file instead)

--- a/src/command-exec-validator.ts
+++ b/src/command-exec-validator.ts
@@ -46,8 +46,6 @@ export function extractCommandFromFindExec(command: string): string {
   return '';
 }
 
-// getDenyCommandMessage moved to utils/command-utils.js
-
 /**
  * コマンド実行コマンド（xargs, find -execなど）の判定とコマンドの抽出
  * @param baseCommand ベースコマンド

--- a/src/command-exec-validator.ts
+++ b/src/command-exec-validator.ts
@@ -1,0 +1,106 @@
+import { ShellCommandConfig } from './config/shell-command-config.js';
+import {
+  findCommandInAllowlist,
+  getDenyCommandName,
+  getDenyCommandMessage,
+} from './utils/command-utils.js';
+import { ValidationResult } from './command-validator.js';
+
+/**
+ * コマンド導入コマンドのリスト
+ * xargsや-execオプションを持つfindなど、引数として他のコマンドを実行するもの
+ */
+export const COMMANDS_THAT_EXECUTE_OTHER_COMMANDS = ['xargs', 'find'];
+
+/**
+ * xargsコマンドから実行されるコマンドを抽出する関数
+ * @param command xargsを含むコマンド文字列
+ * @returns 抽出されたコマンド名（見つからない場合は空文字列）
+ */
+export function extractCommandFromXargs(command: string): string {
+  // xargsの後の最初の引数がコマンドとみなされる
+  const parts = command.trim().split(/\s+/);
+  const xargsIndex = parts.findIndex((part) => part === 'xargs');
+
+  if (xargsIndex >= 0 && xargsIndex + 1 < parts.length) {
+    return parts[xargsIndex + 1];
+  }
+
+  return '';
+}
+
+/**
+ * find -exec/-execdir オプションから実行されるコマンドを抽出する関数
+ * @param command findコマンドを含む文字列
+ * @returns 抽出されたコマンド名（見つからない場合は空文字列）
+ */
+export function extractCommandFromFindExec(command: string): string {
+  // -exec または -execdir オプションを検索
+  const execPattern = /\s+-exec(?:dir)?\s+(\S+)/;
+  const match = command.match(execPattern);
+
+  if (match && match[1]) {
+    return match[1];
+  }
+
+  return '';
+}
+
+// getDenyCommandMessage moved to utils/command-utils.js
+
+/**
+ * コマンド実行コマンド（xargs, find -execなど）の判定とコマンドの抽出
+ * @param baseCommand ベースコマンド
+ * @param command コマンド全体
+ * @param config 設定オブジェクト
+ * @param result 現在の結果オブジェクト
+ * @returns 検証結果、問題なければnull、問題あればValidationResult
+ */
+export function validateCommandExecCommand(
+  baseCommand: string,
+  command: string,
+  config: ShellCommandConfig,
+  result: ValidationResult
+): ValidationResult | null {
+  // 他のコマンドを実行するコマンド（xargsやfind）の場合、引数のコマンドをチェック
+  let extractedCommand = '';
+
+  if (baseCommand === 'xargs') {
+    extractedCommand = extractCommandFromXargs(command);
+  } else if (baseCommand === 'find' && command.includes('-exec')) {
+    extractedCommand = extractCommandFromFindExec(command);
+  }
+
+  if (extractedCommand) {
+    // ブラックリストチェック
+    const blacklistedCmd = config.denyCommands.find((denyCmd) => {
+      const cmdName = getDenyCommandName(denyCmd);
+      return cmdName === extractedCommand;
+    });
+
+    if (blacklistedCmd) {
+      return {
+        ...result,
+        message: getDenyCommandMessage(blacklistedCmd, config),
+        blockReason: {
+          denyCommand: blacklistedCmd,
+          location: 'validateCommandWithArgs:blacklistedCommandInExec',
+        },
+      };
+    }
+
+    // ホワイトリストチェック
+    const matchedAllowCommand = findCommandInAllowlist(extractedCommand, config.allowCommands);
+    if (!matchedAllowCommand) {
+      return {
+        ...result,
+        message: `${config.defaultErrorMessage}: ${extractedCommand} (in ${baseCommand})`,
+        blockReason: {
+          location: 'validateCommandWithArgs:commandInExecNotInAllowlist',
+        },
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/command-validator.ts
+++ b/src/command-validator.ts
@@ -1,5 +1,14 @@
 import { getConfig } from './config/config-loader.js';
-import { AllowCommand, DenyCommand, ShellCommandConfig } from './config/shell-command-config.js';
+import { AllowCommand, DenyCommand } from './config/shell-command-config.js';
+import {
+  findCommandInAllowlist,
+  getDenyCommandName,
+  getDenyCommandMessage,
+} from './utils/command-utils.js';
+import {
+  COMMANDS_THAT_EXECUTE_OTHER_COMMANDS,
+  validateCommandExecCommand,
+} from './command-exec-validator.js';
 
 // シェル演算子の正規表現パターン
 const SHELL_OPERATORS_REGEX = /([;|&]|&&|\|\||\(|\)|\{|\})/g;
@@ -27,14 +36,7 @@ export function checkForOutputRedirection(commandString: string): string | null 
   return null;
 }
 
-export function getCommandName(
-  commandStr: string | { command: string; subCommands?: string[] }
-): string {
-  if (typeof commandStr === 'string') {
-    return commandStr;
-  }
-  return commandStr.command;
-}
+// getCommandName function moved to utils/command-utils.js
 
 export type ValidationResult = {
   isValid: boolean;
@@ -48,137 +50,11 @@ export type ValidationResult = {
   };
 };
 
-/**
- * コマンドが許可リストに含まれているか確認する関数
- * @param commandName 確認するコマンド名
- * @param allowCommands 許可コマンドリスト
- * @returns マッチした許可コマンド、見つからない場合はnull
- */
-export function findCommandInAllowlist(
-  commandName: string,
-  allowCommands: AllowCommand[]
-): AllowCommand | null {
-  const matchedCommand = allowCommands.find((cmd) => {
-    const cmdName = getCommandName(cmd);
-    return cmdName === commandName;
-  });
+// findCommandInAllowlist function moved to utils/command-utils.js
 
-  return matchedCommand || null;
-}
+// getDenyCommandName and getDenyCommandMessage moved to appropriate utility files
 
-/**
- * DenyCommandからコマンド名を抽出
- */
-function getDenyCommandName(denyCmd: DenyCommand): string {
-  return typeof denyCmd === 'string' ? denyCmd : denyCmd.command;
-}
-
-/**
- * DenyCommandからエラーメッセージを取得する関数
- */
-function getDenyCommandMessage(denyCommand: DenyCommand, config: ShellCommandConfig): string {
-  if (typeof denyCommand === 'object' && denyCommand.message) {
-    return denyCommand.message;
-  }
-  return config.defaultErrorMessage;
-}
-
-/**
- * コマンド導入コマンドのリスト
- * xargsや-execオプションを持つfindなど、引数として他のコマンドを実行するもの
- */
-const COMMANDS_THAT_EXECUTE_OTHER_COMMANDS = ['xargs', 'find'];
-
-/**
- * xargsコマンドから実行されるコマンドを抽出する関数
- * @param command xargsを含むコマンド文字列
- * @returns 抽出されたコマンド名（見つからない場合は空文字列）
- */
-export function extractCommandFromXargs(command: string): string {
-  // xargsの後の最初の引数がコマンドとみなされる
-  const parts = command.trim().split(/\s+/);
-  const xargsIndex = parts.findIndex((part) => part === 'xargs');
-
-  if (xargsIndex >= 0 && xargsIndex + 1 < parts.length) {
-    return parts[xargsIndex + 1];
-  }
-
-  return '';
-}
-
-/**
- * find -exec/-execdir オプションから実行されるコマンドを抽出する関数
- * @param command findコマンドを含む文字列
- * @returns 抽出されたコマンド名（見つからない場合は空文字列）
- */
-export function extractCommandFromFindExec(command: string): string {
-  // -exec または -execdir オプションを検索
-  const execPattern = /\s+-exec(?:dir)?\s+(\S+)/;
-  const match = command.match(execPattern);
-
-  if (match && match[1]) {
-    return match[1];
-  }
-
-  return '';
-}
-
-/**
- * コマンド実行コマンド（xargs, find -execなど）の判定とコマンドの抽出
- * @param baseCommand ベースコマンド
- * @param command コマンド全体
- * @param config 設定オブジェクト
- * @param result 現在の結果オブジェクト
- * @returns 検証結果、問題なければnull、問題あればValidationResult
- */
-function validateCommandExecCommand(
-  baseCommand: string,
-  command: string,
-  config: ShellCommandConfig,
-  result: ValidationResult
-): ValidationResult | null {
-  // 他のコマンドを実行するコマンド（xargsやfind）の場合、引数のコマンドをチェック
-  let extractedCommand = '';
-
-  if (baseCommand === 'xargs') {
-    extractedCommand = extractCommandFromXargs(command);
-  } else if (baseCommand === 'find' && command.includes('-exec')) {
-    extractedCommand = extractCommandFromFindExec(command);
-  }
-
-  if (extractedCommand) {
-    // ブラックリストチェック
-    const blacklistedCmd = config.denyCommands.find((denyCmd) => {
-      const cmdName = getDenyCommandName(denyCmd);
-      return cmdName === extractedCommand;
-    });
-
-    if (blacklistedCmd) {
-      return {
-        ...result,
-        message: getDenyCommandMessage(blacklistedCmd, config),
-        blockReason: {
-          denyCommand: blacklistedCmd,
-          location: 'validateCommandWithArgs:blacklistedCommandInExec',
-        },
-      };
-    }
-
-    // ホワイトリストチェック
-    const matchedAllowCommand = findCommandInAllowlist(extractedCommand, config.allowCommands);
-    if (!matchedAllowCommand) {
-      return {
-        ...result,
-        message: `${config.defaultErrorMessage}: ${extractedCommand} (in ${baseCommand})`,
-        blockReason: {
-          location: 'validateCommandWithArgs:commandInExecNotInAllowlist',
-        },
-      };
-    }
-  }
-
-  return null;
-}
+// Command validation functions and constants moved to command-exec-validator.js
 
 /**
  * コマンドが許可リストに登録されているか検証する関数
@@ -224,10 +100,13 @@ export function validateCommandWithArgs(command: string): ValidationResult {
   }
 
   if (COMMANDS_THAT_EXECUTE_OTHER_COMMANDS.includes(baseCommand)) {
+    // Validate commands executed by other commands (like xargs or find -exec)
     const execCommandResult = validateCommandExecCommand(baseCommand, command, config, result);
     if (execCommandResult) {
       return execCommandResult;
     }
+
+    // Note: The old for loop that checked arguments has been removed as it's now handled by validateCommandExecCommand
   }
 
   // 直接findCommandInAllowlistを使って許可リストチェックを行う

--- a/src/directory-manager.ts
+++ b/src/directory-manager.ts
@@ -2,24 +2,10 @@ import path from 'path';
 import fs from 'fs';
 import { getConfig } from './config/config-loader.js';
 
-// Parse allowed directories from environment variable (for backward compatibility)
-export function parseAllowedDirectories(): string[] {
-  const allowedDirsEnv = process.env.MCP_ALLOWED_DIRECTORIES;
-  if (!allowedDirsEnv) {
-    return [];
-  }
-  return allowedDirsEnv
-    .split(':')
-    .map((dir) => dir.trim())
-    .filter((dir) => dir.length > 0);
-}
-
-// Gets the allowed directories from config and environment variables (for backward compatibility)
+// Gets the allowed directories from config
 export function getAllowedDirectoriesFromConfig(): string[] {
   const config = getConfig();
-  // First use directories from config, then add ones from environment variables for backward compatibility
-  const envDirectories = parseAllowedDirectories();
-  return [...config.allowedDirectories, ...envDirectories];
+  return [...config.allowedDirectories];
 }
 
 // If not set, no directories are allowed
@@ -69,9 +55,7 @@ export function isDirectoryAllowed(dir: string): boolean {
  */
 export function setWorkingDirectory(dir: string): string {
   if (!isDirectoryAllowed(dir)) {
-    throw new Error(
-      `Directory not allowed: ${dir}. Must be within: ${ALLOWED_DIRECTORIES.join(', ')}`
-    );
+    throw new Error(`Directory not allowed: ${dir}. Must be within one of the allowed directories`);
   }
 
   currentWorkingDirectory = path.resolve(dir);

--- a/src/tests/command-exec-validator.spec.ts
+++ b/src/tests/command-exec-validator.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  extractCommandFromXargs,
+  extractCommandFromFindExec,
+  validateCommandExecCommand,
+  COMMANDS_THAT_EXECUTE_OTHER_COMMANDS,
+} from '../command-exec-validator.js';
+import * as configLoader from '../config/config-loader.js';
+import { ValidationResult } from '../command-validator.js';
+
+vi.mock('../config/config-loader.js', () => {
+  const mockConfig = {
+    allowedDirectories: ['/tmp', __dirname],
+    allowCommands: [
+      'ls',
+      'cat',
+      'echo',
+      'grep',
+      'wc',
+      'date',
+      'xargs',
+      'find',
+      {
+        command: 'git',
+        subCommands: ['status', 'log'],
+      },
+      {
+        command: 'npm',
+        denySubCommands: ['install', 'uninstall', 'update', 'audit'],
+      },
+    ],
+    denyCommands: [
+      { command: 'rm', message: 'rm is dangerous' },
+      { command: 'sudo', message: 'sudo is not allowed' },
+      { command: 'chmod', message: 'chmod is not allowed' },
+    ],
+    defaultErrorMessage: 'Command not allowed',
+  };
+  return {
+    getConfig: vi.fn(() => mockConfig),
+    reloadConfig: vi.fn(() => mockConfig),
+  };
+});
+
+describe('COMMANDS_THAT_EXECUTE_OTHER_COMMANDS', () => {
+  it('should include xargs and find', () => {
+    expect(COMMANDS_THAT_EXECUTE_OTHER_COMMANDS).toContain('xargs');
+    expect(COMMANDS_THAT_EXECUTE_OTHER_COMMANDS).toContain('find');
+  });
+});
+
+describe('extractCommandFromXargs', () => {
+  it('should extract command name from xargs command string', () => {
+    expect(extractCommandFromXargs('xargs ls')).toBe('ls');
+    expect(extractCommandFromXargs('xargs cat')).toBe('cat');
+    expect(extractCommandFromXargs('xargs echo')).toBe('echo');
+    expect(extractCommandFromXargs('find . -name "*.txt" | xargs grep pattern')).toBe('grep');
+  });
+
+  it('should return empty string if no command is found after xargs', () => {
+    expect(extractCommandFromXargs('xargs')).toBe('');
+    expect(extractCommandFromXargs('command xargs')).toBe('');
+  });
+
+  it('should handle whitespace properly', () => {
+    expect(extractCommandFromXargs('xargs     ls')).toBe('ls');
+    expect(extractCommandFromXargs('  xargs  cat  ')).toBe('cat');
+  });
+});
+
+describe('extractCommandFromFindExec', () => {
+  it('should extract command name from find -exec option', () => {
+    expect(extractCommandFromFindExec('find . -exec ls {} ;')).toBe('ls');
+    expect(extractCommandFromFindExec('find . -name "*.txt" -exec cat {} ;')).toBe('cat');
+    expect(extractCommandFromFindExec('find . -type f -exec chmod 644 {} ;')).toBe('chmod');
+  });
+
+  it('should extract command name from find -execdir option', () => {
+    expect(extractCommandFromFindExec('find . -execdir ls {} ;')).toBe('ls');
+    expect(extractCommandFromFindExec('find . -name "*.txt" -execdir cat {} ;')).toBe('cat');
+  });
+
+  it('should return empty string if no -exec option is found', () => {
+    expect(extractCommandFromFindExec('find . -name "*.txt"')).toBe('');
+    expect(extractCommandFromFindExec('grep pattern file.txt')).toBe('');
+  });
+});
+
+describe('validateCommandExecCommand', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return null for valid exec commands', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'xargs ls',
+      baseCommand: 'xargs',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('xargs', 'xargs ls', config, baseResult);
+    expect(result).toBeNull();
+  });
+
+  it('should detect blacklisted commands in exec', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'xargs rm',
+      baseCommand: 'xargs',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('xargs', 'xargs rm', config, baseResult);
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.isValid).toBe(false);
+      expect(result.message).toBe('rm is dangerous');
+      expect(result.blockReason?.location).toBe('validateCommandWithArgs:blacklistedCommandInExec');
+    }
+  });
+
+  it('should detect commands not in allowlist in exec', () => {
+    const mockConfig = {
+      allowedDirectories: ['/', '/tmp'],
+      allowCommands: ['ls', 'cat', 'echo', 'xargs', 'find'],
+      denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
+      defaultErrorMessage: 'Command not allowed',
+    };
+    vi.spyOn(configLoader, 'getConfig').mockReturnValue(mockConfig);
+
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'xargs grep',
+      baseCommand: 'xargs',
+      message: '',
+      allowedCommands: mockConfig.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('xargs', 'xargs grep', mockConfig, baseResult);
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.isValid).toBe(false);
+      expect(result.message).toBe('Command not allowed: grep (in xargs)');
+      expect(result.blockReason?.location).toBe(
+        'validateCommandWithArgs:commandInExecNotInAllowlist'
+      );
+    }
+  });
+
+  it('should handle find -exec commands correctly', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'find . -exec ls {} \\;',
+      baseCommand: 'find',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('find', 'find . -exec ls {} \\;', config, baseResult);
+    expect(result).toBeNull();
+
+    // With blacklisted command
+    const resultWithBlacklisted = validateCommandExecCommand(
+      'find',
+      'find . -exec rm {} \\;',
+      config,
+      baseResult
+    );
+    expect(resultWithBlacklisted).not.toBeNull();
+    if (resultWithBlacklisted) {
+      expect(resultWithBlacklisted.isValid).toBe(false);
+      expect(resultWithBlacklisted.message).toBe('rm is dangerous');
+    }
+  });
+
+  it('should return null if no exec command found', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'find . -name "*.txt"',
+      baseCommand: 'find',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('find', 'find . -name "*.txt"', config, baseResult);
+    expect(result).toBeNull();
+  });
+});

--- a/src/tests/command-validator.spec.ts
+++ b/src/tests/command-validator.spec.ts
@@ -5,39 +5,11 @@ import {
   extractCommands,
   validateMultipleCommands,
   checkForOutputRedirection,
+  extractCommandFromXargs,
+  extractCommandFromFindExec,
+  isCommandInAllowlist,
 } from '../command-validator.js';
 import * as configLoader from '../config/config-loader.js';
-import { AllowCommand } from '../config/shell-command-config.js';
-
-// Internal helper functions for tests
-function extractCommandFromXargs(command: string): string {
-  const parts = command.trim().split(/\s+/);
-  const xargsIndex = parts.findIndex((part) => part === 'xargs');
-
-  if (xargsIndex >= 0 && xargsIndex + 1 < parts.length) {
-    return parts[xargsIndex + 1];
-  }
-
-  return '';
-}
-
-function extractCommandFromFindExec(command: string): string {
-  const execPattern = /\s+-exec(?:dir)?\s+(\S+)/;
-  const match = command.match(execPattern);
-
-  if (match && match[1]) {
-    return match[1];
-  }
-
-  return '';
-}
-
-function isCommandInAllowlist(commandName: string, allowCommands: AllowCommand[]): boolean {
-  return allowCommands.some((cmd) => {
-    const cmdName = getCommandName(cmd);
-    return cmdName === commandName;
-  });
-}
 
 vi.mock('../config/config-loader.js', () => {
   const mockConfig = {

--- a/src/tests/command-validator.spec.ts
+++ b/src/tests/command-validator.spec.ts
@@ -7,7 +7,7 @@ import {
   checkForOutputRedirection,
   extractCommandFromXargs,
   extractCommandFromFindExec,
-  isCommandInAllowlist,
+  findCommandInAllowlist,
 } from '../command-validator.js';
 import * as configLoader from '../config/config-loader.js';
 
@@ -277,8 +277,8 @@ describe('extractCommandFromFindExec', () => {
   });
 });
 
-describe('isCommandInAllowlist', () => {
-  it('should check if a command is in the allowlist', () => {
+describe('findCommandInAllowlist', () => {
+  it('should return the matching command from the allowlist', () => {
     const allowCommands = [
       'ls',
       'cat',
@@ -287,19 +287,25 @@ describe('isCommandInAllowlist', () => {
       { command: 'npm', denySubCommands: ['install', 'uninstall'] },
     ];
 
-    expect(isCommandInAllowlist('ls', allowCommands)).toBe(true);
-    expect(isCommandInAllowlist('cat', allowCommands)).toBe(true);
-    expect(isCommandInAllowlist('echo', allowCommands)).toBe(true);
-    expect(isCommandInAllowlist('git', allowCommands)).toBe(true);
-    expect(isCommandInAllowlist('npm', allowCommands)).toBe(true);
+    expect(findCommandInAllowlist('ls', allowCommands)).toBe('ls');
+    expect(findCommandInAllowlist('cat', allowCommands)).toBe('cat');
+    expect(findCommandInAllowlist('echo', allowCommands)).toBe('echo');
+    expect(findCommandInAllowlist('git', allowCommands)).toEqual({
+      command: 'git',
+      subCommands: ['status', 'log'],
+    });
+    expect(findCommandInAllowlist('npm', allowCommands)).toEqual({
+      command: 'npm',
+      denySubCommands: ['install', 'uninstall'],
+    });
 
-    expect(isCommandInAllowlist('rm', allowCommands)).toBe(false);
-    expect(isCommandInAllowlist('cp', allowCommands)).toBe(false);
-    expect(isCommandInAllowlist('sudo', allowCommands)).toBe(false);
+    expect(findCommandInAllowlist('rm', allowCommands)).toBeNull();
+    expect(findCommandInAllowlist('cp', allowCommands)).toBeNull();
+    expect(findCommandInAllowlist('sudo', allowCommands)).toBeNull();
   });
 
-  it('should return false for empty allowlist', () => {
-    expect(isCommandInAllowlist('ls', [])).toBe(false);
+  it('should return null for empty allowlist', () => {
+    expect(findCommandInAllowlist('ls', [])).toBeNull();
   });
 });
 

--- a/src/tests/command-validator.spec.ts
+++ b/src/tests/command-validator.spec.ts
@@ -369,7 +369,7 @@ describe('Complex cases with find and xargs', () => {
     expect(validateCommandWithArgs('find . -name "*.log" | xargs grep "error"').isValid).toBe(true);
 
     // 禁止コマンドを実行する場合
-    expect(validateCommandWithArgs('find . -type f -mtime +30 | xargs rm').isValid).toBe(false);
+    expect(validateMultipleCommands('find . -type f -mtime +30 | xargs rm').isValid).toBe(false);
   });
 });
 

--- a/src/tests/command-validator.spec.ts
+++ b/src/tests/command-validator.spec.ts
@@ -322,6 +322,22 @@ describe('extractCommands', () => {
     expect(commands.length).toBe(2); // 2つのコマンドを抽出
   });
 
+  it('should extract commands from brace groups', () => {
+    const input = '{ ls -la; echo test; }';
+    const commands = extractCommands(input);
+    expect(commands).toContain('ls -la');
+    expect(commands).toContain('echo test');
+    expect(commands.length).toBe(2); // 2つのコマンドを抽出
+  });
+
+  it('should extract commands from parenthesis groups', () => {
+    const input = '(ls -la; echo test)';
+    const commands = extractCommands(input);
+    expect(commands).toContain('ls -la');
+    expect(commands).toContain('echo test');
+    expect(commands.length).toBe(2); // 2つのコマンドを抽出
+  });
+
   it('should extract commands from complex combinations', () => {
     const input = 'ls -la | grep .js && echo $(date) || echo "failed"';
     const commands = extractCommands(input);

--- a/src/tests/directory-manager.spec.ts
+++ b/src/tests/directory-manager.spec.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import { getConfig } from '../config/config-loader.js';
 import {
-  parseAllowedDirectories,
   refreshAllowedDirectories,
   getAllowedDirectoriesFromConfig,
   isDirectoryAllowed,
@@ -38,7 +37,7 @@ describe('Directory Management', () => {
     }
 
     // Set up allowed directories for testing
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', testBaseDir);
+    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([testBaseDir]);
     refreshAllowedDirectories();
 
     // Create test directory and file if they don't exist
@@ -110,124 +109,35 @@ describe('Directory Management', () => {
   });
 });
 
-// ALLOWED_DIRECTORIESの環境変数からの読み込みテスト
+// 設定ファイルからのALLOWED_DIRECTORIESの読み込みテスト
 describe('getAllowedDirectoriesFromConfig', () => {
-  // 環境変数のモックを管理するために、afterEachフックを追加
   afterEach(() => {
-    // 環境変数のモックをリセット
-    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
-  it('should merge directories from config and environment variables', () => {
+  it('should return directories from config', () => {
     // Mock configuration
     vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([
       '/config/dir1',
       '/config/dir2',
     ]);
-    // Mock environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/env/dir1:/env/dir2');
 
     const result = getAllowedDirectoriesFromConfig();
 
-    // Should include directories from both sources
-    expect(result).toContain('/config/dir1');
-    expect(result).toContain('/config/dir2');
-    expect(result).toContain('/env/dir1');
-    expect(result).toContain('/env/dir2');
-    expect(result.length).toBe(4);
-  });
-
-  it('should work with only config directories', () => {
-    // Mock configuration
-    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([
-      '/config/dir1',
-      '/config/dir2',
-    ]);
-    // Empty environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '');
-
-    const result = getAllowedDirectoriesFromConfig();
-
-    // Should include only config directories
+    // Should include directories from config
     expect(result).toContain('/config/dir1');
     expect(result).toContain('/config/dir2');
     expect(result.length).toBe(2);
   });
 
-  it('should work with only environment variable directories', () => {
+  it('should return empty array when config is empty', () => {
     // Empty config
     vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([]);
-    // Mock environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/env/dir1:/env/dir2');
-
-    const result = getAllowedDirectoriesFromConfig();
-
-    // Should include only environment variable directories
-    expect(result).toContain('/env/dir1');
-    expect(result).toContain('/env/dir2');
-    expect(result.length).toBe(2);
-  });
-
-  it('should return empty array when both sources are empty', () => {
-    // Empty config
-    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([]);
-    // Empty environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '');
 
     const result = getAllowedDirectoriesFromConfig();
 
     // Should be empty
     expect(result.length).toBe(0);
-  });
-});
-
-describe('parseAllowedDirectories', () => {
-  // 環境変数のモックを管理するために、afterEachフックを追加
-  afterEach(() => {
-    // 環境変数のモックをリセット
-    vi.unstubAllEnvs();
-  });
-
-  // 各テスト後に環境変数の変更をALLOWED_DIRECTORIESに反映させる
-  beforeEach(() => {
-    // 現在の環境変数を保存
-    refreshAllowedDirectories();
-  });
-
-  it('should return empty array when environment variable is not set', () => {
-    // 環境変数が存在しない場合
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', undefined);
-    expect(parseAllowedDirectories()).toEqual([]);
-  });
-
-  it('should return empty array when environment variable is empty', () => {
-    // 環境変数が空文字列の場合
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '');
-    expect(parseAllowedDirectories()).toEqual([]);
-  });
-
-  it('should parse colon-separated directories', () => {
-    // 標準的なケース: コロン区切りのディレクトリリスト
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/home/user:/tmp:/var/log');
-    expect(parseAllowedDirectories()).toEqual(['/home/user', '/tmp', '/var/log']);
-  });
-
-  it('should filter out empty entries', () => {
-    // 空のエントリを含むケース
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/home/user::/tmp::/var/log');
-    expect(parseAllowedDirectories()).toEqual(['/home/user', '/tmp', '/var/log']);
-  });
-
-  it('should handle single directory', () => {
-    // ディレクトリが1つだけのケース
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/home/user');
-    expect(parseAllowedDirectories()).toEqual(['/home/user']);
-  });
-
-  it('should trim whitespace from directories', () => {
-    // 空白を含むケース
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', ' /home/user : /tmp : /var/log ');
-    expect(parseAllowedDirectories()).toEqual(['/home/user', '/tmp', '/var/log']);
   });
 });
 
@@ -252,7 +162,7 @@ describe('handleShellCommand with Directory Parameter', () => {
     }
 
     // Set up allowed directories for testing
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', testBaseDir);
+    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([testBaseDir]);
     refreshAllowedDirectories();
     // Create test directory if it doesn't exist
     if (!fs.existsSync(testDir)) {

--- a/src/tests/utils/command-utils.spec.ts
+++ b/src/tests/utils/command-utils.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCommandName,
+  findCommandInAllowlist,
+  getDenyCommandName,
+  getDenyCommandMessage,
+} from '../../utils/command-utils.js';
+import { ShellCommandConfig } from '../../config/shell-command-config.js';
+
+describe('getCommandName', () => {
+  it('should extract command name from string', () => {
+    expect(getCommandName('ls')).toBe('ls');
+    expect(getCommandName('git')).toBe('git');
+    expect(getCommandName('npm')).toBe('npm');
+  });
+
+  it('should extract command name from object with command property', () => {
+    expect(getCommandName({ command: 'git' })).toBe('git');
+    expect(getCommandName({ command: 'npm' })).toBe('npm');
+  });
+
+  it('should extract command name from object with command and subCommands properties', () => {
+    expect(getCommandName({ command: 'git', subCommands: ['status', 'log'] })).toBe('git');
+    expect(getCommandName({ command: 'npm', subCommands: ['install', 'run'] })).toBe('npm');
+  });
+});
+
+describe('findCommandInAllowlist', () => {
+  it('should return the matching command from the allowlist', () => {
+    const allowCommands = [
+      'ls',
+      'cat',
+      'echo',
+      { command: 'git', subCommands: ['status', 'log'] },
+      { command: 'npm', denySubCommands: ['install', 'uninstall'] },
+    ];
+
+    expect(findCommandInAllowlist('ls', allowCommands)).toBe('ls');
+    expect(findCommandInAllowlist('cat', allowCommands)).toBe('cat');
+    expect(findCommandInAllowlist('echo', allowCommands)).toBe('echo');
+    expect(findCommandInAllowlist('git', allowCommands)).toEqual({
+      command: 'git',
+      subCommands: ['status', 'log'],
+    });
+    expect(findCommandInAllowlist('npm', allowCommands)).toEqual({
+      command: 'npm',
+      denySubCommands: ['install', 'uninstall'],
+    });
+
+    expect(findCommandInAllowlist('rm', allowCommands)).toBeNull();
+    expect(findCommandInAllowlist('cp', allowCommands)).toBeNull();
+    expect(findCommandInAllowlist('sudo', allowCommands)).toBeNull();
+  });
+
+  it('should return null for empty allowlist', () => {
+    expect(findCommandInAllowlist('ls', [])).toBeNull();
+  });
+});
+
+describe('getDenyCommandName', () => {
+  it('should extract command name from string deny command', () => {
+    expect(getDenyCommandName('rm')).toBe('rm');
+    expect(getDenyCommandName('sudo')).toBe('sudo');
+  });
+
+  it('should extract command name from object deny command', () => {
+    expect(getDenyCommandName({ command: 'rm', message: 'rm is dangerous' })).toBe('rm');
+    expect(getDenyCommandName({ command: 'sudo', message: 'sudo is not allowed' })).toBe('sudo');
+  });
+});
+
+describe('getDenyCommandMessage', () => {
+  it('should return custom message from deny command object if available', () => {
+    const config: ShellCommandConfig = {
+      allowedDirectories: ['/tmp'],
+      allowCommands: ['ls', 'cat'],
+      denyCommands: [],
+      defaultErrorMessage: 'Command not allowed',
+    };
+
+    const denyCmd = { command: 'rm', message: 'rm is dangerous' };
+    expect(getDenyCommandMessage(denyCmd, config)).toBe('rm is dangerous');
+  });
+
+  it('should return default error message if deny command is string', () => {
+    const config: ShellCommandConfig = {
+      allowedDirectories: ['/tmp'],
+      allowCommands: ['ls', 'cat'],
+      denyCommands: [],
+      defaultErrorMessage: 'Command not allowed',
+    };
+
+    expect(getDenyCommandMessage('rm', config)).toBe('Command not allowed');
+  });
+
+  it('should return default error message if deny command object has no message', () => {
+    const config: ShellCommandConfig = {
+      allowedDirectories: ['/tmp'],
+      allowCommands: ['ls', 'cat'],
+      denyCommands: [],
+      defaultErrorMessage: 'Command not allowed',
+    };
+
+    const denyCmd = { command: 'rm' };
+    expect(getDenyCommandMessage(denyCmd, config)).toBe('Command not allowed');
+  });
+});

--- a/src/utils/command-utils.ts
+++ b/src/utils/command-utils.ts
@@ -1,0 +1,58 @@
+import { AllowCommand, DenyCommand, ShellCommandConfig } from '../config/shell-command-config.js';
+
+/**
+ * コマンド文字列またはオブジェクトからコマンド名を取得する
+ * @param commandStr コマンド文字列またはコマンドオブジェクト
+ * @returns コマンド名
+ */
+export function getCommandName(
+  commandStr: string | { command: string; subCommands?: string[] }
+): string {
+  if (typeof commandStr === 'string') {
+    return commandStr;
+  }
+  return commandStr.command;
+}
+
+/**
+ * コマンドが許可リストに含まれているか確認する関数
+ * @param commandName 確認するコマンド名
+ * @param allowCommands 許可コマンドリスト
+ * @returns マッチした許可コマンド、見つからない場合はnull
+ */
+export function findCommandInAllowlist(
+  commandName: string,
+  allowCommands: AllowCommand[]
+): AllowCommand | null {
+  const matchedCommand = allowCommands.find((cmd) => {
+    const cmdName = getCommandName(cmd);
+    return cmdName === commandName;
+  });
+
+  return matchedCommand || null;
+}
+
+/**
+ * DenyCommandからコマンド名を抽出する関数
+ * @param denyCmd 拒否コマンド
+ * @returns コマンド名
+ */
+export function getDenyCommandName(denyCmd: DenyCommand): string {
+  return typeof denyCmd === 'string' ? denyCmd : denyCmd.command;
+}
+
+/**
+ * DenyCommandからエラーメッセージを取得する関数
+ * @param denyCommand 拒否コマンド
+ * @param config 設定オブジェクト
+ * @returns エラーメッセージ
+ */
+export function getDenyCommandMessage(
+  denyCommand: DenyCommand,
+  config: ShellCommandConfig
+): string {
+  if (typeof denyCommand === 'object' && denyCommand.message) {
+    return denyCommand.message;
+  }
+  return config.defaultErrorMessage;
+}


### PR DESCRIPTION
## Description
Implements feature request from issue #23 to allow xargs and find --exec to use commands that are already on the allowlist.

## Changes
- Added helper function `isCommandInAllowlist` to check if a command is in the allowlist
- Enhanced `validateCommandWithArgs` to extract and validate commands used by xargs and find --exec
- Added thorough tests for the new functionality

## Testing
All tests are passing with the new implementation. Test cases include:
- Basic xargs and find --exec scenarios
- Complex commands with xargs and find --exec
- Verification that blacklisted commands are still properly blocked when used with xargs or find --exec