### PR TITLE
Replace root directory with __dirname in test configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,3 @@ A sample configuration file is provided at `mcp-config.sample.json`.
 ### Environment Variables
 
 - `MCP_CONFIG_PATH`: Path to the configuration file (default: `./mcp-config.json`)
-- `MCP_ALLOWED_DIRECTORIES`: Colon-separated list of directories where commands can be executed (deprecated, use `allowedDirectories` in config file instead)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3,15 +3,36 @@
 .
 ├── LICENSE
 ├── README.md
+├── docs
+│   ├── instructions.md
+│   └── spec.md
 ├── eslint.config.js
+├── mcp-config.sample.json
 ├── package-lock.json
 ├── package.json
 ├── src
-│ ├── index.ts
-│ ├── mcp-server.ts
-│ ├── shell-command-handler.ts
-│ ├── sse.ts
-│ └── tests
-│ └── shell-command-handler.spec.ts
+│   ├── command-exec-validator.ts
+│   ├── command-validator.ts
+│   ├── config
+│   │   ├── config-loader.ts
+│   │   └── shell-command-config.ts
+│   ├── directory-manager.ts
+│   ├── index.ts
+│   ├── logger.ts
+│   ├── mcp-server.ts
+│   ├── shell-command-handler.ts
+│   ├── sse.ts
+│   ├── tests
+│   │   ├── command-exec-validator.spec.ts
+│   │   ├── command-validator.spec.ts
+│   │   ├── config-loader.spec.ts
+│   │   ├── directory-manager.spec.ts
+│   │   ├── logger.spec.ts
+│   │   ├── shell-command-handler.spec.ts
+│   │   └── utils
+│   │   └── command-utils.spec.ts
+│   └── utils
+│   └── command-utils.ts
 ├── tsconfig.json
+├── tsconfig.spec.json
 └── vitest.config.ts

--- a/src/command-exec-validator.ts
+++ b/src/command-exec-validator.ts
@@ -1,0 +1,104 @@
+import { ShellCommandConfig } from './config/shell-command-config.js';
+import {
+  findCommandInAllowlist,
+  getDenyCommandName,
+  getDenyCommandMessage,
+} from './utils/command-utils.js';
+import { ValidationResult } from './command-validator.js';
+
+/**
+ * コマンド導入コマンドのリスト
+ * xargsや-execオプションを持つfindなど、引数として他のコマンドを実行するもの
+ */
+export const COMMANDS_THAT_EXECUTE_OTHER_COMMANDS = ['xargs', 'find'];
+
+/**
+ * xargsコマンドから実行されるコマンドを抽出する関数
+ * @param command xargsを含むコマンド文字列
+ * @returns 抽出されたコマンド名（見つからない場合は空文字列）
+ */
+export function extractCommandFromXargs(command: string): string {
+  // xargsの後の最初の引数がコマンドとみなされる
+  const parts = command.trim().split(/\s+/);
+  const xargsIndex = parts.findIndex((part) => part === 'xargs');
+
+  if (xargsIndex >= 0 && xargsIndex + 1 < parts.length) {
+    return parts[xargsIndex + 1];
+  }
+
+  return '';
+}
+
+/**
+ * find -exec/-execdir オプションから実行されるコマンドを抽出する関数
+ * @param command findコマンドを含む文字列
+ * @returns 抽出されたコマンド名（見つからない場合は空文字列）
+ */
+export function extractCommandFromFindExec(command: string): string {
+  // -exec または -execdir オプションを検索
+  const execPattern = /\s+-exec(?:dir)?\s+(\S+)/;
+  const match = command.match(execPattern);
+
+  if (match && match[1]) {
+    return match[1];
+  }
+
+  return '';
+}
+
+/**
+ * コマンド実行コマンド（xargs, find -execなど）の判定とコマンドの抽出
+ * @param baseCommand ベースコマンド
+ * @param command コマンド全体
+ * @param config 設定オブジェクト
+ * @param result 現在の結果オブジェクト
+ * @returns 検証結果、問題なければnull、問題あればValidationResult
+ */
+export function validateCommandExecCommand(
+  baseCommand: string,
+  command: string,
+  config: ShellCommandConfig,
+  result: ValidationResult
+): ValidationResult | null {
+  // 他のコマンドを実行するコマンド（xargsやfind）の場合、引数のコマンドをチェック
+  let extractedCommand = '';
+
+  if (baseCommand === 'xargs') {
+    extractedCommand = extractCommandFromXargs(command);
+  } else if (baseCommand === 'find' && command.includes('-exec')) {
+    extractedCommand = extractCommandFromFindExec(command);
+  }
+
+  if (extractedCommand) {
+    // ブラックリストチェック
+    const blacklistedCmd = config.denyCommands.find((denyCmd) => {
+      const cmdName = getDenyCommandName(denyCmd);
+      return cmdName === extractedCommand;
+    });
+
+    if (blacklistedCmd) {
+      return {
+        ...result,
+        message: getDenyCommandMessage(blacklistedCmd, config),
+        blockReason: {
+          denyCommand: blacklistedCmd,
+          location: 'validateCommandWithArgs:blacklistedCommandInExec',
+        },
+      };
+    }
+
+    // ホワイトリストチェック
+    const matchedAllowCommand = findCommandInAllowlist(extractedCommand, config.allowCommands);
+    if (!matchedAllowCommand) {
+      return {
+        ...result,
+        message: `${config.defaultErrorMessage}: ${extractedCommand} (in ${baseCommand})`,
+        blockReason: {
+          location: 'validateCommandWithArgs:commandInExecNotInAllowlist',
+        },
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/command-validator.ts
+++ b/src/command-validator.ts
@@ -129,7 +129,7 @@ export function validateCommandWithArgs(command: string): ValidationResult {
   if (matchedCommand === undefined) {
     return {
       ...result,
-      message: config.defaultErrorMessage,
+      message: `${config.defaultErrorMessage}: ${baseCommand}`,
       blockReason: {
         location: 'validateCommandWithArgs:commandNotInAllowlist',
       },
@@ -146,7 +146,7 @@ export function validateCommandWithArgs(command: string): ValidationResult {
     if (matchedCommand.denySubCommands && matchedCommand.denySubCommands.includes(subCommand)) {
       return {
         ...result,
-        message: config.defaultErrorMessage,
+        message: `${config.defaultErrorMessage}: ${baseCommand} ${subCommand}`,
         blockReason: {
           location: 'validateCommandWithArgs:deniedSubcommand',
           denyCommand: { command: `${baseCommand} ${subCommand}` },
@@ -159,7 +159,9 @@ export function validateCommandWithArgs(command: string): ValidationResult {
       return {
         ...result,
         isValid,
-        message: isValid ? 'allowed subcommand' : config.defaultErrorMessage,
+        message: isValid
+          ? 'allowed subcommand'
+          : `${config.defaultErrorMessage}: ${baseCommand} ${subCommand}`,
         ...(!isValid && {
           blockReason: {
             location: 'validateCommandWithArgs:subcommandNotInAllowlist',

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -34,7 +34,7 @@ export function loadConfig(): ShellCommandConfig {
 
     // デフォルト値がない場合は設定
     if (!config.defaultErrorMessage) {
-      config.defaultErrorMessage = 'このコマンドは許可リストに含まれていないため実行できません。';
+      config.defaultErrorMessage = 'このコマンドは許可リストに含まれていないため実行できません';
     }
 
     // ノート: blockLogPathはデフォルトでは設定しない。

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -50,12 +50,7 @@ export function loadConfig(): ShellCommandConfig {
 /**
  * 現在の設定を保持する変数
  */
-let currentConfig: ShellCommandConfig = {
-  allowedDirectories: [],
-  allowCommands: [],
-  denyCommands: [],
-  defaultErrorMessage: 'config not found',
-};
+let currentConfig: ShellCommandConfig | null = null;
 
 /**
  * 設定を再読み込みする関数
@@ -69,5 +64,6 @@ export function reloadConfig(): ShellCommandConfig {
  * 現在の設定を取得する関数
  */
 export function getConfig(): ShellCommandConfig {
+  currentConfig = currentConfig ?? loadConfig();
   return currentConfig;
 }

--- a/src/directory-manager.ts
+++ b/src/directory-manager.ts
@@ -2,24 +2,10 @@ import path from 'path';
 import fs from 'fs';
 import { getConfig } from './config/config-loader.js';
 
-// Parse allowed directories from environment variable (for backward compatibility)
-export function parseAllowedDirectories(): string[] {
-  const allowedDirsEnv = process.env.MCP_ALLOWED_DIRECTORIES;
-  if (!allowedDirsEnv) {
-    return [];
-  }
-  return allowedDirsEnv
-    .split(':')
-    .map((dir) => dir.trim())
-    .filter((dir) => dir.length > 0);
-}
-
-// Gets the allowed directories from config and environment variables (for backward compatibility)
+// Gets the allowed directories from config
 export function getAllowedDirectoriesFromConfig(): string[] {
   const config = getConfig();
-  // First use directories from config, then add ones from environment variables for backward compatibility
-  const envDirectories = parseAllowedDirectories();
-  return [...config.allowedDirectories, ...envDirectories];
+  return [...config.allowedDirectories];
 }
 
 // If not set, no directories are allowed
@@ -69,9 +55,7 @@ export function isDirectoryAllowed(dir: string): boolean {
  */
 export function setWorkingDirectory(dir: string): string {
   if (!isDirectoryAllowed(dir)) {
-    throw new Error(
-      `Directory not allowed: ${dir}. Must be within: ${ALLOWED_DIRECTORIES.join(', ')}`
-    );
+    throw new Error(`Directory not allowed: ${dir}. Must be within one of the allowed directories`);
   }
 
   currentWorkingDirectory = path.resolve(dir);

--- a/src/shell-command-handler.ts
+++ b/src/shell-command-handler.ts
@@ -44,7 +44,7 @@ export async function handleShellCommand(
     const validationResult = validateMultipleCommands(command);
     if (validationResult.isValid === false) {
       logBlockedCommand(command, validationResult);
-      throw new Error(`${validationResult.message}\nCommand: ${command}`);
+      throw new Error(`${validationResult.message}\nBlocked command: ${command}`);
     }
 
     // コマンド実行

--- a/src/tests/command-exec-validator.spec.ts
+++ b/src/tests/command-exec-validator.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import path from 'path';
 import {
   extractCommandFromXargs,
   extractCommandFromFindExec,
@@ -10,7 +11,7 @@ import { ValidationResult } from '../command-validator.js';
 
 vi.mock('../config/config-loader.js', () => {
   const mockConfig = {
-    allowedDirectories: ['/tmp', __dirname],
+    allowedDirectories: [path.join(__dirname, 'tmp'), __dirname],
     allowCommands: [
       'ls',
       'cat',
@@ -126,7 +127,7 @@ describe('validateCommandExecCommand', () => {
 
   it('should detect commands not in allowlist in exec', () => {
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'echo', 'xargs', 'find'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',

--- a/src/tests/command-exec-validator.spec.ts
+++ b/src/tests/command-exec-validator.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  extractCommandFromXargs,
+  extractCommandFromFindExec,
+  validateCommandExecCommand,
+  COMMANDS_THAT_EXECUTE_OTHER_COMMANDS,
+} from '../command-exec-validator.js';
+import * as configLoader from '../config/config-loader.js';
+import { ValidationResult } from '../command-validator.js';
+
+vi.mock('../config/config-loader.js', () => {
+  const mockConfig = {
+    allowedDirectories: ['/tmp', __dirname],
+    allowCommands: [
+      'ls',
+      'cat',
+      'echo',
+      'grep',
+      'wc',
+      'date',
+      'xargs',
+      'find',
+      {
+        command: 'git',
+        subCommands: ['status', 'log'],
+      },
+      {
+        command: 'npm',
+        denySubCommands: ['install', 'uninstall', 'update', 'audit'],
+      },
+    ],
+    denyCommands: [
+      { command: 'rm', message: 'rm is dangerous' },
+      { command: 'sudo', message: 'sudo is not allowed' },
+      { command: 'chmod', message: 'chmod is not allowed' },
+    ],
+    defaultErrorMessage: 'Command not allowed',
+  };
+  return {
+    getConfig: vi.fn(() => mockConfig),
+    reloadConfig: vi.fn(() => mockConfig),
+  };
+});
+
+describe('COMMANDS_THAT_EXECUTE_OTHER_COMMANDS', () => {
+  it('should include xargs and find', () => {
+    expect(COMMANDS_THAT_EXECUTE_OTHER_COMMANDS).toContain('xargs');
+    expect(COMMANDS_THAT_EXECUTE_OTHER_COMMANDS).toContain('find');
+  });
+});
+
+describe('extractCommandFromXargs', () => {
+  it('should extract command name from xargs command string', () => {
+    expect(extractCommandFromXargs('xargs ls')).toBe('ls');
+    expect(extractCommandFromXargs('xargs cat')).toBe('cat');
+    expect(extractCommandFromXargs('xargs echo')).toBe('echo');
+    expect(extractCommandFromXargs('find . -name "*.txt" | xargs grep pattern')).toBe('grep');
+  });
+
+  it('should return empty string if no command is found after xargs', () => {
+    expect(extractCommandFromXargs('xargs')).toBe('');
+    expect(extractCommandFromXargs('command xargs')).toBe('');
+  });
+
+  it('should handle whitespace properly', () => {
+    expect(extractCommandFromXargs('xargs     ls')).toBe('ls');
+    expect(extractCommandFromXargs('  xargs  cat  ')).toBe('cat');
+  });
+});
+
+describe('extractCommandFromFindExec', () => {
+  it('should extract command name from find -exec option', () => {
+    expect(extractCommandFromFindExec('find . -exec ls {} ;')).toBe('ls');
+    expect(extractCommandFromFindExec('find . -name "*.txt" -exec cat {} ;')).toBe('cat');
+    expect(extractCommandFromFindExec('find . -type f -exec chmod 644 {} ;')).toBe('chmod');
+  });
+
+  it('should extract command name from find -execdir option', () => {
+    expect(extractCommandFromFindExec('find . -execdir ls {} ;')).toBe('ls');
+    expect(extractCommandFromFindExec('find . -name "*.txt" -execdir cat {} ;')).toBe('cat');
+  });
+
+  it('should return empty string if no -exec option is found', () => {
+    expect(extractCommandFromFindExec('find . -name "*.txt"')).toBe('');
+    expect(extractCommandFromFindExec('grep pattern file.txt')).toBe('');
+  });
+});
+
+describe('validateCommandExecCommand', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return null for valid exec commands', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'xargs ls',
+      baseCommand: 'xargs',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('xargs', 'xargs ls', config, baseResult);
+    expect(result).toBeNull();
+  });
+
+  it('should detect blacklisted commands in exec', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'xargs rm',
+      baseCommand: 'xargs',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('xargs', 'xargs rm', config, baseResult);
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.isValid).toBe(false);
+      expect(result.message).toBe('rm is dangerous');
+      expect(result.blockReason?.location).toBe('validateCommandWithArgs:blacklistedCommandInExec');
+    }
+  });
+
+  it('should detect commands not in allowlist in exec', () => {
+    const mockConfig = {
+      allowedDirectories: ['/', '/tmp'],
+      allowCommands: ['ls', 'cat', 'echo', 'xargs', 'find'],
+      denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
+      defaultErrorMessage: 'Command not allowed',
+    };
+    vi.spyOn(configLoader, 'getConfig').mockReturnValue(mockConfig);
+
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'xargs grep',
+      baseCommand: 'xargs',
+      message: '',
+      allowedCommands: mockConfig.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('xargs', 'xargs grep', mockConfig, baseResult);
+    expect(result).not.toBeNull();
+    if (result) {
+      expect(result.isValid).toBe(false);
+      expect(result.message).toBe('Command not allowed: grep (in xargs)');
+      expect(result.blockReason?.location).toBe(
+        'validateCommandWithArgs:commandInExecNotInAllowlist'
+      );
+    }
+  });
+
+  it('should handle find -exec commands correctly', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'find . -exec ls {} \\;',
+      baseCommand: 'find',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('find', 'find . -exec ls {} \\;', config, baseResult);
+    expect(result).toBeNull();
+
+    // With blacklisted command
+    const resultWithBlacklisted = validateCommandExecCommand(
+      'find',
+      'find . -exec rm {} \\;',
+      config,
+      baseResult
+    );
+    expect(resultWithBlacklisted).not.toBeNull();
+    if (resultWithBlacklisted) {
+      expect(resultWithBlacklisted.isValid).toBe(false);
+      expect(resultWithBlacklisted.message).toBe('rm is dangerous');
+    }
+  });
+
+  it('should return null if no exec command found', () => {
+    const config = configLoader.getConfig();
+    const baseResult: ValidationResult = {
+      isValid: false,
+      command: 'find . -name "*.txt"',
+      baseCommand: 'find',
+      message: '',
+      allowedCommands: config.allowCommands,
+    };
+
+    const result = validateCommandExecCommand('find', 'find . -name "*.txt"', config, baseResult);
+    expect(result).toBeNull();
+  });
+});

--- a/src/tests/command-validator.spec.ts
+++ b/src/tests/command-validator.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import path from 'path';
 import {
   validateCommandWithArgs,
   extractCommands,
@@ -9,7 +10,7 @@ import * as configLoader from '../config/config-loader.js';
 
 vi.mock('../config/config-loader.js', () => {
   const mockConfig = {
-    allowedDirectories: ['/tmp', __dirname],
+    allowedDirectories: [path.join(__dirname, 'tmp'), __dirname],
     allowCommands: [
       'ls',
       'cat',
@@ -114,7 +115,7 @@ describe('validateCommandWithArgs', () => {
   it('should handle special patterns for blacklisted commands', () => {
     // テスト用設定でrm、sudo、chmod、findがブラックリストに含まれていることを想定
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: [
         'ls',
         'cat',
@@ -170,7 +171,7 @@ describe('validateCommandWithArgs', () => {
   it('should reject blacklisted commands', () => {
     // テスト用設定でrmとsudoがブラックリストに含まれていることを想定
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'git', 'echo'],
       denyCommands: [
         { command: 'rm', message: 'rm is dangerous' },
@@ -195,7 +196,7 @@ describe('validateCommandWithArgs', () => {
 
   it('should detect blacklisted commands in command execution arguments', () => {
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'xargs', 'find', 'echo'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',
@@ -215,7 +216,7 @@ describe('validateCommandWithArgs', () => {
 
   it('should validate xargs commands are in the allowlist', () => {
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'echo', 'xargs'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',
@@ -237,7 +238,7 @@ describe('validateCommandWithArgs', () => {
 describe('Complex cases with find and xargs', () => {
   it('should handle complex commands with find -exec', () => {
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['find', 'ls', 'grep', 'cat', 'chmod', 'echo'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',
@@ -260,7 +261,7 @@ describe('Complex cases with find and xargs', () => {
 
   it('should handle complex commands with xargs', () => {
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['find', 'ls', 'grep', 'cat', 'chmod', 'echo', 'xargs'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',
@@ -469,7 +470,7 @@ describe('validateMultipleCommands', () => {
   it('should return deny command info when blacklisted command is found', () => {
     // テスト用設定
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'echo', 'grep', 'date'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',
@@ -518,7 +519,7 @@ describe('validateMultipleCommands', () => {
   it('should handle more complex pipe and combination cases', () => {
     // テスト用設定
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'git', 'echo', 'grep', 'wc', 'xargs', 'date'],
       denyCommands: [
         { command: 'rm', message: 'rm is dangerous' },
@@ -556,7 +557,7 @@ describe('validateMultipleCommands', () => {
   it('should reject if command substitution contains disallowed commands', () => {
     // テスト用設定
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'echo', 'grep', 'date', 'find', 'xargs'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',
@@ -576,7 +577,7 @@ describe('validateMultipleCommands', () => {
   it('should detect exec option in find command correctly', () => {
     // テスト用設定
     const mockConfig = {
-      allowedDirectories: ['/', '/tmp'],
+      allowedDirectories: [__dirname, path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat', 'echo', 'find', 'chmod'],
       denyCommands: [{ command: 'rm', message: 'rm is dangerous' }],
       defaultErrorMessage: 'Command not allowed',

--- a/src/tests/command-validator.spec.ts
+++ b/src/tests/command-validator.spec.ts
@@ -36,7 +36,6 @@ vi.mock('../config/config-loader.js', () => {
   };
   return {
     getConfig: vi.fn(() => mockConfig),
-    loadConfig: vi.fn(() => mockConfig),
     reloadConfig: vi.fn(() => mockConfig),
   };
 });

--- a/src/tests/config-loader.spec.ts
+++ b/src/tests/config-loader.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import path from 'path';
 import * as configLoader from '../config/config-loader.js';
 import { CONFIG_NOT_FOUND_ERROR } from '../config/config-loader.js';
 import { ShellCommandConfig } from '../config/shell-command-config.js';
@@ -11,7 +12,7 @@ describe('Config Loader', () => {
 
   // テスト用の標準的な設定オブジェクト
   const mockConfig: ShellCommandConfig = {
-    allowedDirectories: ['/test-dir'],
+    allowedDirectories: [path.join(__dirname, 'test-dir')],
     allowCommands: ['ls', 'pwd', 'cd'],
     denyCommands: ['rm', 'sudo'],
     defaultErrorMessage: '許可されていないコマンドです。',
@@ -86,7 +87,7 @@ describe('Config Loader', () => {
     vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
       return JSON.stringify({
         // allowCommandsがない
-        allowedDirectories: ['/test-dir'],
+        allowedDirectories: [path.join(__dirname, 'test-dir')],
         denyCommands: ['rm', 'sudo'],
       });
     });
@@ -109,7 +110,7 @@ describe('Config Loader', () => {
     // 設定値が正しいか確認
     expect(config.allowCommands).toContain('ls');
     expect(config.denyCommands).toContain('rm');
-    expect(config.allowedDirectories).toContain('/test-dir');
+    expect(config.allowedDirectories).toContain(path.join(__dirname, 'test-dir'));
     expect(config.defaultErrorMessage).toBe('許可されていないコマンドです。');
   });
 

--- a/src/tests/directory-manager.spec.ts
+++ b/src/tests/directory-manager.spec.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import path from 'path';
 import { getConfig } from '../config/config-loader.js';
 import {
-  parseAllowedDirectories,
   refreshAllowedDirectories,
   getAllowedDirectoriesFromConfig,
   isDirectoryAllowed,
@@ -38,7 +37,7 @@ describe('Directory Management', () => {
     }
 
     // Set up allowed directories for testing
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', testBaseDir);
+    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([testBaseDir]);
     refreshAllowedDirectories();
 
     // Create test directory and file if they don't exist
@@ -110,124 +109,35 @@ describe('Directory Management', () => {
   });
 });
 
-// ALLOWED_DIRECTORIESの環境変数からの読み込みテスト
+// 設定ファイルからのALLOWED_DIRECTORIESの読み込みテスト
 describe('getAllowedDirectoriesFromConfig', () => {
-  // 環境変数のモックを管理するために、afterEachフックを追加
   afterEach(() => {
-    // 環境変数のモックをリセット
-    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
-  it('should merge directories from config and environment variables', () => {
+  it('should return directories from config', () => {
     // Mock configuration
     vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([
       '/config/dir1',
       '/config/dir2',
     ]);
-    // Mock environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/env/dir1:/env/dir2');
 
     const result = getAllowedDirectoriesFromConfig();
 
-    // Should include directories from both sources
-    expect(result).toContain('/config/dir1');
-    expect(result).toContain('/config/dir2');
-    expect(result).toContain('/env/dir1');
-    expect(result).toContain('/env/dir2');
-    expect(result.length).toBe(4);
-  });
-
-  it('should work with only config directories', () => {
-    // Mock configuration
-    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([
-      '/config/dir1',
-      '/config/dir2',
-    ]);
-    // Empty environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '');
-
-    const result = getAllowedDirectoriesFromConfig();
-
-    // Should include only config directories
+    // Should include directories from config
     expect(result).toContain('/config/dir1');
     expect(result).toContain('/config/dir2');
     expect(result.length).toBe(2);
   });
 
-  it('should work with only environment variable directories', () => {
+  it('should return empty array when config is empty', () => {
     // Empty config
     vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([]);
-    // Mock environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/env/dir1:/env/dir2');
-
-    const result = getAllowedDirectoriesFromConfig();
-
-    // Should include only environment variable directories
-    expect(result).toContain('/env/dir1');
-    expect(result).toContain('/env/dir2');
-    expect(result.length).toBe(2);
-  });
-
-  it('should return empty array when both sources are empty', () => {
-    // Empty config
-    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([]);
-    // Empty environment variable
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '');
 
     const result = getAllowedDirectoriesFromConfig();
 
     // Should be empty
     expect(result.length).toBe(0);
-  });
-});
-
-describe('parseAllowedDirectories', () => {
-  // 環境変数のモックを管理するために、afterEachフックを追加
-  afterEach(() => {
-    // 環境変数のモックをリセット
-    vi.unstubAllEnvs();
-  });
-
-  // 各テスト後に環境変数の変更をALLOWED_DIRECTORIESに反映させる
-  beforeEach(() => {
-    // 現在の環境変数を保存
-    refreshAllowedDirectories();
-  });
-
-  it('should return empty array when environment variable is not set', () => {
-    // 環境変数が存在しない場合
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', undefined);
-    expect(parseAllowedDirectories()).toEqual([]);
-  });
-
-  it('should return empty array when environment variable is empty', () => {
-    // 環境変数が空文字列の場合
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '');
-    expect(parseAllowedDirectories()).toEqual([]);
-  });
-
-  it('should parse colon-separated directories', () => {
-    // 標準的なケース: コロン区切りのディレクトリリスト
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/home/user:/tmp:/var/log');
-    expect(parseAllowedDirectories()).toEqual(['/home/user', '/tmp', '/var/log']);
-  });
-
-  it('should filter out empty entries', () => {
-    // 空のエントリを含むケース
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/home/user::/tmp::/var/log');
-    expect(parseAllowedDirectories()).toEqual(['/home/user', '/tmp', '/var/log']);
-  });
-
-  it('should handle single directory', () => {
-    // ディレクトリが1つだけのケース
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', '/home/user');
-    expect(parseAllowedDirectories()).toEqual(['/home/user']);
-  });
-
-  it('should trim whitespace from directories', () => {
-    // 空白を含むケース
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', ' /home/user : /tmp : /var/log ');
-    expect(parseAllowedDirectories()).toEqual(['/home/user', '/tmp', '/var/log']);
   });
 });
 
@@ -252,7 +162,7 @@ describe('handleShellCommand with Directory Parameter', () => {
     }
 
     // Set up allowed directories for testing
-    vi.stubEnv('MCP_ALLOWED_DIRECTORIES', testBaseDir);
+    vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([testBaseDir]);
     refreshAllowedDirectories();
     // Create test directory if it doesn't exist
     if (!fs.existsSync(testDir)) {

--- a/src/tests/directory-manager.spec.ts
+++ b/src/tests/directory-manager.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach, afterAll } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 import { getConfig } from '../config/config-loader.js';
 import {
   refreshAllowedDirectories,
@@ -68,7 +69,7 @@ describe('Directory Management', () => {
     expect(isDirectoryAllowed(testDir)).toBe(true);
 
     // Directories outside test base directory should not be allowed
-    const outsideDir = path.join('/', 'tmp', 'test-outside');
+    const outsideDir = path.join(os.tmpdir(), 'test-outside');
     expect(isDirectoryAllowed(outsideDir)).toBe(false);
 
     // Non-directories should not be allowed
@@ -95,7 +96,7 @@ describe('Directory Management', () => {
 
   it('should throw an error when setting an invalid directory', () => {
     // Try to set to a directory outside allowed directories
-    const outsideDir = path.join('/', 'tmp', 'test-outside');
+    const outsideDir = path.join(os.tmpdir(), 'test-outside');
     expect(() => setWorkingDirectory(outsideDir)).toThrow(/Directory not allowed/);
 
     // Try to set to a non-existent directory
@@ -118,15 +119,15 @@ describe('getAllowedDirectoriesFromConfig', () => {
   it('should return directories from config', () => {
     // Mock configuration
     vi.spyOn(getConfig(), 'allowedDirectories', 'get').mockReturnValue([
-      '/config/dir1',
-      '/config/dir2',
+      path.join(__dirname, 'config', 'dir1'),
+      path.join(__dirname, 'config', 'dir2'),
     ]);
 
     const result = getAllowedDirectoriesFromConfig();
 
     // Should include directories from config
-    expect(result).toContain('/config/dir1');
-    expect(result).toContain('/config/dir2');
+    expect(result).toContain(path.join(__dirname, 'config', 'dir1'));
+    expect(result).toContain(path.join(__dirname, 'config', 'dir2'));
     expect(result.length).toBe(2);
   });
 

--- a/src/tests/shell-command-handler.spec.ts
+++ b/src/tests/shell-command-handler.spec.ts
@@ -186,7 +186,7 @@ describe('handleShellCommand', () => {
     // Verify custom error message is used
     expect(result.content[0].text).toContain('rm is dangerous, use trash-cli instead');
     // Verify command is included in error
-    expect(result.content[0].text).toContain('Command: rm -rf /');
+    expect(result.content[0].text).toContain('Blocked command: rm -rf /');
     // Verify the logger was called with the correct arguments
     expect(logSpy).toHaveBeenCalledWith(
       command,

--- a/src/tests/utils/command-utils.spec.ts
+++ b/src/tests/utils/command-utils.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getCommandName,
+  findCommandInAllowlist,
+  getDenyCommandName,
+  getDenyCommandMessage,
+} from '../../utils/command-utils.js';
+import { ShellCommandConfig } from '../../config/shell-command-config.js';
+
+describe('getCommandName', () => {
+  it('should extract command name from string', () => {
+    expect(getCommandName('ls')).toBe('ls');
+    expect(getCommandName('git')).toBe('git');
+    expect(getCommandName('npm')).toBe('npm');
+  });
+
+  it('should extract command name from object with command property', () => {
+    expect(getCommandName({ command: 'git' })).toBe('git');
+    expect(getCommandName({ command: 'npm' })).toBe('npm');
+  });
+
+  it('should extract command name from object with command and subCommands properties', () => {
+    expect(getCommandName({ command: 'git', subCommands: ['status', 'log'] })).toBe('git');
+    expect(getCommandName({ command: 'npm', subCommands: ['install', 'run'] })).toBe('npm');
+  });
+});
+
+describe('findCommandInAllowlist', () => {
+  it('should return the matching command from the allowlist', () => {
+    const allowCommands = [
+      'ls',
+      'cat',
+      'echo',
+      { command: 'git', subCommands: ['status', 'log'] },
+      { command: 'npm', denySubCommands: ['install', 'uninstall'] },
+    ];
+
+    expect(findCommandInAllowlist('ls', allowCommands)).toBe('ls');
+    expect(findCommandInAllowlist('cat', allowCommands)).toBe('cat');
+    expect(findCommandInAllowlist('echo', allowCommands)).toBe('echo');
+    expect(findCommandInAllowlist('git', allowCommands)).toEqual({
+      command: 'git',
+      subCommands: ['status', 'log'],
+    });
+    expect(findCommandInAllowlist('npm', allowCommands)).toEqual({
+      command: 'npm',
+      denySubCommands: ['install', 'uninstall'],
+    });
+
+    expect(findCommandInAllowlist('rm', allowCommands)).toBeNull();
+    expect(findCommandInAllowlist('cp', allowCommands)).toBeNull();
+    expect(findCommandInAllowlist('sudo', allowCommands)).toBeNull();
+  });
+
+  it('should return null for empty allowlist', () => {
+    expect(findCommandInAllowlist('ls', [])).toBeNull();
+  });
+});
+
+describe('getDenyCommandName', () => {
+  it('should extract command name from string deny command', () => {
+    expect(getDenyCommandName('rm')).toBe('rm');
+    expect(getDenyCommandName('sudo')).toBe('sudo');
+  });
+
+  it('should extract command name from object deny command', () => {
+    expect(getDenyCommandName({ command: 'rm', message: 'rm is dangerous' })).toBe('rm');
+    expect(getDenyCommandName({ command: 'sudo', message: 'sudo is not allowed' })).toBe('sudo');
+  });
+});
+
+describe('getDenyCommandMessage', () => {
+  it('should return custom message from deny command object if available', () => {
+    const config: ShellCommandConfig = {
+      allowedDirectories: ['/tmp'],
+      allowCommands: ['ls', 'cat'],
+      denyCommands: [],
+      defaultErrorMessage: 'Command not allowed',
+    };
+
+    const denyCmd = { command: 'rm', message: 'rm is dangerous' };
+    expect(getDenyCommandMessage(denyCmd, config)).toBe('rm is dangerous');
+  });
+
+  it('should return default error message if deny command is string', () => {
+    const config: ShellCommandConfig = {
+      allowedDirectories: ['/tmp'],
+      allowCommands: ['ls', 'cat'],
+      denyCommands: [],
+      defaultErrorMessage: 'Command not allowed',
+    };
+
+    expect(getDenyCommandMessage('rm', config)).toBe('Command not allowed');
+  });
+
+  it('should return default error message if deny command object has no message', () => {
+    const config: ShellCommandConfig = {
+      allowedDirectories: ['/tmp'],
+      allowCommands: ['ls', 'cat'],
+      denyCommands: [],
+      defaultErrorMessage: 'Command not allowed',
+    };
+
+    const denyCmd = { command: 'rm' };
+    expect(getDenyCommandMessage(denyCmd, config)).toBe('Command not allowed');
+  });
+});

--- a/src/tests/utils/command-utils.spec.ts
+++ b/src/tests/utils/command-utils.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import path from 'path';
 import {
   getCommandName,
   findCommandInAllowlist,
@@ -72,7 +73,7 @@ describe('getDenyCommandName', () => {
 describe('getDenyCommandMessage', () => {
   it('should return custom message from deny command object if available', () => {
     const config: ShellCommandConfig = {
-      allowedDirectories: ['/tmp'],
+      allowedDirectories: [path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat'],
       denyCommands: [],
       defaultErrorMessage: 'Command not allowed',
@@ -84,7 +85,7 @@ describe('getDenyCommandMessage', () => {
 
   it('should return default error message if deny command is string', () => {
     const config: ShellCommandConfig = {
-      allowedDirectories: ['/tmp'],
+      allowedDirectories: [path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat'],
       denyCommands: [],
       defaultErrorMessage: 'Command not allowed',
@@ -95,7 +96,7 @@ describe('getDenyCommandMessage', () => {
 
   it('should return default error message if deny command object has no message', () => {
     const config: ShellCommandConfig = {
-      allowedDirectories: ['/tmp'],
+      allowedDirectories: [path.join(__dirname, 'tmp')],
       allowCommands: ['ls', 'cat'],
       denyCommands: [],
       defaultErrorMessage: 'Command not allowed',

--- a/src/utils/command-utils.ts
+++ b/src/utils/command-utils.ts
@@ -1,0 +1,58 @@
+import { AllowCommand, DenyCommand, ShellCommandConfig } from '../config/shell-command-config.js';
+
+/**
+ * コマンド文字列またはオブジェクトからコマンド名を取得する
+ * @param commandStr コマンド文字列またはコマンドオブジェクト
+ * @returns コマンド名
+ */
+export function getCommandName(
+  commandStr: string | { command: string; subCommands?: string[] }
+): string {
+  if (typeof commandStr === 'string') {
+    return commandStr;
+  }
+  return commandStr.command;
+}
+
+/**
+ * コマンドが許可リストに含まれているか確認する関数
+ * @param commandName 確認するコマンド名
+ * @param allowCommands 許可コマンドリスト
+ * @returns マッチした許可コマンド、見つからない場合はnull
+ */
+export function findCommandInAllowlist(
+  commandName: string,
+  allowCommands: AllowCommand[]
+): AllowCommand | null {
+  const matchedCommand = allowCommands.find((cmd) => {
+    const cmdName = getCommandName(cmd);
+    return cmdName === commandName;
+  });
+
+  return matchedCommand || null;
+}
+
+/**
+ * DenyCommandからコマンド名を抽出する関数
+ * @param denyCmd 拒否コマンド
+ * @returns コマンド名
+ */
+export function getDenyCommandName(denyCmd: DenyCommand): string {
+  return typeof denyCmd === 'string' ? denyCmd : denyCmd.command;
+}
+
+/**
+ * DenyCommandからエラーメッセージを取得する関数
+ * @param denyCommand 拒否コマンド
+ * @param config 設定オブジェクト
+ * @returns エラーメッセージ
+ */
+export function getDenyCommandMessage(
+  denyCommand: DenyCommand,
+  config: ShellCommandConfig
+): string {
+  if (typeof denyCommand === 'object' && denyCommand.message) {
+    return denyCommand.message;
+  }
+  return config.defaultErrorMessage;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
       ignoreSourceErrors: false,
       tsconfig: './tsconfig.json',
     },
-    env: {},
+    env: {
+      MCP_CONFIG_PATH: './mcp-config.sample.json',
+    },
   },
 });


### PR DESCRIPTION
This PR replaces all instances of '/' root directory with `__dirname` in test configurations to improve security.